### PR TITLE
Fix JSON resolution error and improve user privacy protection

### DIFF
--- a/auto.py
+++ b/auto.py
@@ -95,10 +95,10 @@ def main(username, password):
     dk.login()
     print("3. 获取打卡信息")
     dk.get_info()
-    print("4. 准备为%s同学打卡" % dk.info['name'])
+    print("4. 准备为学号末尾为%s的同学打卡" % dk.info['number'][-3:])
     res = dk.post()
     if str(res['e']) == '0':
-        print('☑︎为%s打卡成功' % dk.info['name'])
+        print('☑︎为%s同学打卡成功' % dk.info['number'][-3:])
     else:
         print('☒%s' % res['m'])
 

--- a/auto.py
+++ b/auto.py
@@ -67,7 +67,7 @@ class DaKa:
 
         jsontext = eval(data1[data1.find("{"):data1.rfind(";")].replace(" ", ""))
         geo_text = jsontext['geo_api_info']
-        geo_text = geo_text.replace("false", "False").replace("true", "True")
+        geo_text = geo_text.replace("false", "\"FALSE\"").replace("true", "\"TRUE\"").replace("null","\"NULL\"")
         geo_obj = eval(geo_text)['addressComponent']
         area = geo_obj['province'] + " " + geo_obj['city'] + " " + geo_obj['district']
         name = re.findall(r'realname: "([^\"]+)",', content1)[0]


### PR DESCRIPTION
In some cases, geo_text will include some text without quote, which will cause json parsing errors.
![image](https://user-images.githubusercontent.com/29459113/120060238-33614f80-c089-11eb-8292-fa8fc129a8b1.png)

So, in this pull request, we fix this error. And protect user privacy by outputting only the last few digits of the user's student ID.